### PR TITLE
Optional streamable-HTTP transport for remote hosting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Unreleased
 - new `reorder_playlist_tracks` tool: move a contiguous block of tracks to a new
   position within a playlist (zero-based positions, optional snapshot guard)
+- optional **streamable-HTTP transport** for remote hosting: set
+  `SPOTIFY_MCP_TRANSPORT=streamable-http` (host/port/stateless/bearer via env)
+- headless OAuth: seed a `SPOTIFY_REFRESH_TOKEN` or `SPOTIFY_CACHE_PATH` so hosted
+  deploys never need a browser; local stdio still auto-opens one
+- `deploy/modal_app.py` + Dockerfile/EXPOSE notes for deploying to Modal (stateless)
+  or self-hosting; see `PLAN.md` for the full deployment guide
 
 ## 2026-05-29 — 0.3.1
 - add the `mcp-name:` ownership marker to the README so the MCP Registry can

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,11 @@ RUN addgroup -g 1001 -S spotify && \
 
 USER spotify
 
+# Default is stdio. For remote/streamable-HTTP hosting, run with:
+#   -e SPOTIFY_MCP_TRANSPORT=streamable-http -e SPOTIFY_MCP_HOST=0.0.0.0 -p 8000:8000
+# and supply SPOTIFY_CLIENT_ID/SECRET plus a headless token
+# (SPOTIFY_REFRESH_TOKEN, or SPOTIFY_CACHE_PATH on a mounted volume).
+EXPOSE 8000
+
 # Command to run the MCP server
 CMD ["spotify-mcp"]

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,149 @@
+# Plan: streamable-HTTP transport + remote deployment
+
+## Context
+
+Today this server is **stdio-only**: `main()` in `src/spotify_mcp/__init__.py` calls
+`mcp.run()`, which defaults to stdio, and auth is a module-level singleton
+(`spotify_api.Client()`) using spotipy's `SpotifyOAuth` with a local
+`CacheFileHandler`. That's great for a local install but means it can't be hosted
+anywhere — every client has to run the process itself.
+
+Goal: let the same server *optionally* speak **streamable-HTTP** so it can be deployed
+remotely — **homelab first**, with **Modal** as the cloud option (the user has a Modal
+account). Competitive research (`research/spotify-mcp-landscape.md`) found that remote/
+HTTP transport is rare across Spotify MCPs and a genuine differentiator; the abandoned
+leader (varunneal, 602★) is stdio-only, and only niche projects (iceener, qchuchu) are
+remote-capable.
+
+The transport flag is the *easy* part. The real work is **headless OAuth**: a hosted
+server has no browser to complete the Spotify auth dance and an ephemeral filesystem, so
+the refresh token must be supplied out-of-band and persisted.
+
+## What's already in our favor
+
+- FastMCP 1.27.1 (`from mcp.server.fastmcp import FastMCP`) **already supports**
+  `transport="streamable-http"` and exposes `mcp.streamable_http_app()` (a Starlette ASGI
+  app) plus settings: `host`, `port`, `streamable_http_path`, `stateless_http`,
+  `json_response`, `auth`. No dependency bump needed.
+- A `Dockerfile` already exists (multi-stage, non-root) — it just runs the stdio command.
+- spotipy ships `MemoryCacheHandler` and `RedisCacheHandler` alongside `CacheFileHandler`,
+  so headless token seeding is supported without new deps.
+
+> Note: we use the **official `mcp` SDK's** FastMCP, not the standalone `fastmcp`
+> (gofastmcp) package. So it's `mcp.settings.stateless_http = True` + `mcp.run(...)` /
+> `mcp.streamable_http_app()` — *not* `mcp.http_app(...)`, which is the other package.
+
+## Implementation
+
+### 1. Make transport configurable — `src/spotify_mcp/__init__.py`
+
+Select transport from env so stdio stays the zero-config default:
+
+- `SPOTIFY_MCP_TRANSPORT` = `stdio` (default) | `streamable-http`
+- when http: read `SPOTIFY_MCP_HOST` (default `127.0.0.1`), `SPOTIFY_MCP_PORT`
+  (default `8000`), and `SPOTIFY_MCP_STATELESS` (default off; **set on Modal**).
+- set `mcp.settings.host/port/stateless_http` before `mcp.run(transport=...)`.
+
+Keep the SIGPIPE/BrokenPipe handling for stdio; it's harmless under http.
+
+### 2. Headless OAuth — `src/spotify_mcp/spotify_api.py` (the actual work)
+
+Current `Client.__init__` always builds a default file-cache `SpotifyOAuth`. Add a
+headless path that activates when a refresh token / explicit cache location is provided:
+
+- **`SPOTIFY_REFRESH_TOKEN`** present → seed a `MemoryCacheHandler` with a token_info
+  dict (`{"refresh_token": ..., "scope": <SCOPES>, "expires_at": 0}`); spotipy refreshes
+  the access token automatically on first call. No browser, no disk needed.
+- else **`SPOTIFY_CACHE_PATH`** present → `CacheFileHandler(cache_path=...)` pointed at a
+  persistent volume (Modal Volume / Docker bind mount / Render disk).
+- pass `open_browser=False` to `SpotifyOAuth` so a hosted process never tries to launch a
+  browser.
+- one-time bootstrap: document running the existing local OAuth flow once to mint the
+  refresh token, then copy it into the deploy target's secret store.
+
+This keeps the **single-user** model (one Spotify account per deployment) — correct for a
+homelab. Multi-user/public hosting (per-session tokens via the MCP `auth` layer) is
+explicitly **out of scope** for v1; note it as a future step.
+
+### 3. Transport-layer auth for remote (lightweight)
+
+Single-user homelab doesn't need full OAuth 2.1. Plan:
+
+- **Network boundary** (recommended): expose only over Tailscale or a Cloudflare Tunnel;
+  no public port. Clients add the server with `claude mcp add --transport http`.
+- **Optional bearer token**: a tiny ASGI middleware on `streamable_http_app()` checking
+  `Authorization: Bearer <SPOTIFY_MCP_BEARER>`; clients pass
+  `--header "Authorization: Bearer …"`. Skip if behind Tailscale.
+
+### 4. Docker — `Dockerfile`
+
+Add an http-friendly variant: `ENV SPOTIFY_MCP_TRANSPORT=streamable-http
+SPOTIFY_MCP_HOST=0.0.0.0`, `EXPOSE 8000`. Keep stdio as the default CMD path so existing
+users are unaffected; http is opt-in via env.
+
+### 5. Modal deploy script — `deploy/modal_app.py` (new)
+
+```python
+import modal
+app = modal.App("spotify-mcp")
+image = modal.Image.debian_slim().pip_install_from_pyproject("pyproject.toml")
+vol = modal.Volume.from_name("spotify-cache", create_if_missing=True)
+
+@app.function(image=image, secrets=[modal.Secret.from_name("spotify")],
+              volumes={"/cache": vol}, min_containers=1)
+@modal.concurrent(max_inputs=100)
+@modal.asgi_app()
+def mcp_web():
+    from spotify_mcp.fastmcp_server import mcp
+    mcp.settings.stateless_http = True   # REQUIRED on Modal (see below)
+    return mcp.streamable_http_app()
+```
+
+- `modal.Secret` "spotify" holds `SPOTIFY_CLIENT_ID/SECRET` + `SPOTIFY_REFRESH_TOKEN`.
+- **Stateless is mandatory on Modal**: Modal hard-caps a request at **150s** and
+  303-redirects past that, which breaks long-lived SSE / stateful streamable-HTTP
+  sessions. `stateless_http=True` makes each request self-contained so autoscaling is
+  safe. `min_containers=1` avoids cold starts; ~\$5/mo compute, inside the \$30 free credit.
+- Caveat to verify: our tools that stream **progress notifications** (`get_playlist_tracks`
+  via `ctx.report_progress`) — confirm they still function under `stateless_http=True`
+  within the 150s window on very large playlists.
+
+## Deployment options (recommendation: homelab now, Modal next)
+
+| Target | Stateful sessions? | Token persistence | Notes |
+|---|---|---|---|
+| **Homelab** (recommended first) | ✅ yes (no caps) | Docker bind mount → `SPOTIFY_CACHE_PATH` | Caddy/Traefik for TLS, or Tailscale/CF Tunnel (no open ports). Cleanest fit. |
+| **Modal** | ❌ stateless only | `modal.Volume` or `SPOTIFY_REFRESH_TOKEN` secret | 150s request cap → must run stateless; `min_containers=1`. |
+| Fly.io | ✅ (1 always-on machine) | Fly Volume | managed; volume pins region; no free tier. |
+| Render | ✅ (single instance + disk) | Render Disk | avoid free tier (15-min sleep, ~1m cold start). |
+
+## Verification
+
+1. **Local http smoke test**: `SPOTIFY_MCP_TRANSPORT=streamable-http uv run spotify-mcp`,
+   then connect with the MCP Inspector or `claude mcp add --transport http spotify
+   http://127.0.0.1:8000/mcp`; list tools, run `search_tracks`, `get_currently_playing`.
+2. **Headless auth**: with only `SPOTIFY_REFRESH_TOKEN` set (no `.cache` file), confirm a
+   tool call succeeds (token auto-refreshes) and no browser is attempted.
+3. **Tests/gates**: `uv run mypy src/` + `uv run pytest`. Add tests for the transport
+   env-var selection and the headless `Client` path (mock spotipy; assert
+   `MemoryCacheHandler` is used and `open_browser=False`).
+4. **Modal**: `modal serve deploy/modal_app.py` (ephemeral) → hit `/mcp`; then
+   `modal deploy`. Verify the Volume persists the refreshed token across a container
+   restart, and a large-playlist progress stream completes under 150s in stateless mode.
+5. **Regression**: default `uv run spotify-mcp` (no env) still starts stdio unchanged.
+
+## Critical files
+
+- `src/spotify_mcp/__init__.py` — transport selection
+- `src/spotify_mcp/spotify_api.py` — headless OAuth (`MemoryCacheHandler` / `cache_path`,
+  `open_browser=False`)
+- `src/spotify_mcp/fastmcp_server.py` — optional bearer-auth middleware on the ASGI app
+- `Dockerfile` — http env/EXPOSE
+- `deploy/modal_app.py` — new, Modal ASGI app
+- `README.md` / `CHANGELOG.md` — document remote mode
+
+## Out of scope (future)
+
+- Multi-user / public hosting with per-session Spotify OAuth via the MCP auth spec
+  (OAuth 2.1 + PKCE, `/.well-known/oauth-protected-resource`).
+- Publishing a hosted endpoint to the MCP registry as a `remote` transport entry.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,21 @@ To run the latest unpublished commit without cloning: `uvx --from git+https://gi
 
 On first use the server opens a browser for Spotify OAuth; the token is cached locally for later runs.
 
+## Remote hosting (streamable-HTTP)
+
+The server speaks stdio by default, but can serve **streamable-HTTP** for remote/hosted
+use. Set `SPOTIFY_MCP_TRANSPORT=streamable-http` (optionally `SPOTIFY_MCP_HOST`,
+`SPOTIFY_MCP_PORT`); clients connect with `claude mcp add --transport http spotify <url>/mcp`.
+
+Because a hosted process has no browser and often an ephemeral disk, supply the OAuth token
+out-of-band: complete the browser flow once locally, then set `SPOTIFY_REFRESH_TOKEN` (or
+point `SPOTIFY_CACHE_PATH` at a persistent volume). Optional `SPOTIFY_MCP_BEARER` gates the
+endpoint behind an `Authorization: Bearer …` header — otherwise keep it on a private network
+(Tailscale / Cloudflare Tunnel).
+
+For a one-command Modal deploy and the homelab/Fly/Render trade-offs, see `PLAN.md` and
+`deploy/modal_app.py`. Note Modal requires stateless mode (`SPOTIFY_MCP_STATELESS=true`).
+
 ## Usage Examples
 
 - **"Create a chill study playlist with 20 tracks"** → Search + playlist creation + bulk track addition

--- a/deploy/modal_app.py
+++ b/deploy/modal_app.py
@@ -1,0 +1,49 @@
+"""Deploy the Spotify MCP server to Modal over streamable-HTTP.
+
+Modal hard-caps each request at ~150s and 303-redirects past that, which breaks
+long-lived/stateful streamable-HTTP sessions — so we run FastMCP in **stateless**
+mode (`SPOTIFY_MCP_STATELESS=true`). See PLAN.md for the full rationale.
+
+Setup (one-time):
+  1. Obtain a Spotify refresh token locally (run the normal stdio server once to
+     complete the browser OAuth flow, then read it from the spotipy `.cache` file).
+  2. Create the secret:
+       modal secret create spotify \\
+         SPOTIFY_CLIENT_ID=... SPOTIFY_CLIENT_SECRET=... SPOTIFY_REFRESH_TOKEN=...
+  3. Serve ephemerally:  modal serve deploy/modal_app.py
+     Deploy for real:    modal deploy deploy/modal_app.py
+  Endpoint: https://<workspace>--spotify-mcp-mcp-web.modal.run/mcp
+
+Connect a client, e.g.:
+  claude mcp add --transport http spotify https://<...>.modal.run/mcp
+"""
+
+from __future__ import annotations
+
+import modal
+
+app = modal.App("spotify-mcp")
+
+image = modal.Image.debian_slim(python_version="3.12").pip_install_from_pyproject(
+    "pyproject.toml"
+)
+
+
+@app.function(
+    image=image,
+    secrets=[modal.Secret.from_name("spotify")],
+    min_containers=1,  # keep one warm to avoid OAuth/init cold starts
+)
+@modal.concurrent(max_inputs=100)
+@modal.asgi_app()
+def mcp_web():  # noqa: ANN201 - Modal infers the ASGI return type
+    # Import inside the function so it runs in the Modal container (with secrets set).
+    from spotify_mcp.fastmcp_server import build_http_app, mcp
+
+    # Stateless is REQUIRED on Modal (150s request cap breaks stateful sessions).
+    mcp.settings.stateless_http = True
+
+    # Optional bearer gate if SPOTIFY_MCP_BEARER is in the secret.
+    import os
+
+    return build_http_app(bearer_token=os.getenv("SPOTIFY_MCP_BEARER"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
  "mcp[cli]>=1.27.1",
  "python-dotenv>=1.2.2",
  "spotipy>=2.26.0",
+ "uvicorn>=0.35.0",
 ]
 [[project.authors]]
 name = "Jamie Dubs"

--- a/research/spotify-mcp-landscape.md
+++ b/research/spotify-mcp-landscape.md
@@ -1,0 +1,92 @@
+# Spotify MCP landscape — competitive research (May 2026)
+
+Survey of other Spotify MCP servers across GitHub, the official MCP Registry, Smithery,
+Glama, PulseMCP, and hosted-MCP providers. Goal: understand what exists, whether anything
+is remotely hosted with managed OAuth, and whether we should switch off our local server.
+
+## TL;DR
+
+- **Don't switch.** Our server is one of the most feature-complete in the field and the only
+  actively-maintained Python one with typed structured output. Nothing else dominates it.
+- **The market leader (varunneal, 602★) is officially abandoned** as of March 2026. We descend
+  from it — clean narrative as the maintained, token-efficient successor.
+- **A capable remote-hosted Spotify MCP with managed OAuth does now exist:** `sptfy-mcp.online`
+  (akutishevsky) — connect by URL, ~80 tools, OAuth walked through on first connect, free.
+  Composio is the managed-platform alternative. Both are worth a look *if* remote is the goal,
+  but neither has our structured-output/elicitation/registry-published polish.
+- **Universal caveat:** playback control requires **Spotify Premium** on *every* server — it's a
+  Spotify Web API restriction, not a server choice.
+
+## Our server (jamiew/spotify-mcp) — baseline
+
+- Python / FastMCP, ~14 tools + 6 resources + 3 prompts. PyPI `spotify-mcp-jamiew`,
+  registry `io.github.jamiew/spotify-mcp`. 7★.
+- Tools: search (track/artist/album/playlist), playback info + control, queue, library
+  (saved/top/recent, save/remove), playlist create/add/remove. Read-only vs destructive
+  annotations; elicitation confirmation on destructive playlist ops.
+- **Differentiators:** typed Pydantic structured-output schemas (real output schema, not raw
+  JSON), tool annotations + icons, progress notifications on long paginations, elicitation
+  prompts, MCP-registry published. Token-efficient via selective field extraction.
+- **Gaps:** stdio/local only (not remote-hostable without a token-persistence layer);
+  no playlist reorder; recommendations/audio-features gone (Spotify deprecated Nov 2024).
+
+## GitHub field
+
+| Project | ★ | Lang | Design | Remote? | Playlist | Maintained | Notes |
+|---|---|---|---|---|---|---|---|
+| **varunneal/spotify-mcp** | 602 | Py (spotipy) | multiplexed `action` tools | stdio only | create/update | **Abandoned** (Mar 2026 "inactive") | OG, most mindshare. We fork its lineage. |
+| **marcelmarais/spotify-mcp-server** | 356 | TS | ~20 one-tool-per-action | stdio only | create+add (no reorder) | **Active** (May 2026) | Healthiest rival; great docs; volume/device granularity. |
+| **iceener/spotify-streamable-mcp-server** | 80 | TS (Node/Bun **or** CF Workers) | **5 batch tools** | **Yes — streamable HTTP** | **Full CRUD incl. reorder** | active-ish (Feb 2026) | Our philosophical twin: batch-first, slim outputs, OAuth2.1+PKCE, device transfer. No Pydantic schemas/elicitation. |
+| **superseoworld/mcp-spotify** ("ArtistLens") | 20 | TS | catalog/metadata | stdio | read + metadata edit | stale (Mar 2025) | **client-credentials only** → no playback, no Premium. Audiobooks. Easy Smithery install. |
+| qchuchu/spotify-mcp-server | 9 | TS | search/playlist/playback | **Yes (hosted demo)** | yes | Sep 2025 | Live Alpic-hosted instance; demo-grade. |
+| LibreChat-AI/spotify-mcp | 10 | TS (CF Workers) | OAuth reference | self-deploy | — | Mar 2026 | OAuth 2.0+PKCE + DCR discovery example, not a full player. |
+| Carrieukie/spotify-mcp-server | 19 | **Kotlin** | playback/playlist | stdio **+ SSE** | yes | Jul 2025 | Rare Kotlin; supports SSE. |
+| vsaez/mcp-spotify-player | 19 | Py | playback | stdio | — | Sep 2025 | Polished CI. |
+
+Plus many sub-5★ forks/clones (igorgarbuz, sespinosa, belljustin, tylerpina, thebigredgeek…).
+
+## Remote-hosted / managed-OAuth options (the part you cared about)
+
+True connect-by-URL servers:
+
+1. **akutishevsky — `https://sptfy-mcp.online/mcp`** ★ best match. Managed PKCE OAuth (auth
+   walked through on first connect, **no API keys / no Spotify dev app**), ~80 tools across ~13
+   categories, full Web API coverage, TOON-formatted (token-efficient) responses, free.
+   Registry: `io.github.akutishevsky/spotify`. *Unverified:* exact rate limits and whether it
+   clears Spotify's 25-user dev-mode cap (repo README wasn't publicly fetchable). One third
+   party holds your token (encrypted per their claim) — trust check warranted.
+2. **Composio — `https://mcp.composio.dev/spotify`** ~84 tools, managed token lifecycle
+   (refresh/rotation), but likely BYO Spotify client ID/secret at setup. Enterprise/managed-
+   platform flavor. Free tier + paid.
+3. **ai.trendsmcp/spotify** — Bearer/API-key, **analytics/trends data only**, no playback/
+   playlists. Not a control server.
+4. **pipeworx-io/spotify** — `client_credentials`, **catalog read only**, no user account.
+5. **Zapier MCP — Spotify** — hosted URL, but **automation actions, not real-time playback**.
+6. **Klavis (Strata)** — hosted MCP w/ managed OAuth, but **couldn't confirm a Spotify connector**.
+
+Self-deploy "remote-capable" (BYO creds, no public endpoint): TylerLeonhardt/spotify-remote-mcp,
+LibreChat-AI/spotify-mcp, and Smithery-buildable servers (@superseoworld, @latiftplgu, @obre10off…).
+
+## Registry counts
+
+- Official MCP Registry: 6 spotify entries — 3 remote HTTP (akutishevsky, trendsmcp, pipeworx),
+  3 local stdio (jamiew = us, khglynn, markswendsen/striderlabs).
+- PulseMCP: "Top 30 Spotify MCP Servers", nearly all local/self-host.
+- Glama: 20 listed (7 remote-capable, 7 local-only, 1 hybrid, 5 unspecified). Glama doesn't host.
+- Smithery: several (exact count blocked by rate-limiting during research).
+
+## Takeaways for positioning
+
+1. Lead with "**maintained, token-efficient, structured-output successor to varunneal**" — the
+   602★ leader is dead and there's no active high-star Python competitor.
+2. Our real differentiators even vs. iceener: **typed Pydantic output schemas, elicitation
+   confirmations, progress notifications, registry-published**. Few/none combine these.
+3. **Gaps worth closing:** playlist **reorder** (only iceener clearly has it), and **remote/HTTP
+   transport** (rare across the field — genuine opening if we want to be hostable).
+4. State the **Premium requirement** plainly in the README; users repeatedly trip on it.
+
+Sources: github.com/varunneal/spotify-mcp, github.com/marcelmarais/spotify-mcp-server,
+github.com/iceener/spotify-streamable-mcp-server, github.com/superseoworld/mcp-spotify,
+sptfy-mcp.online, composio.dev/toolkits/spotify, zapier.com/mcp/spotify,
+registry.modelcontextprotocol.io (search=spotify), pulsemcp.com/servers?q=spotify,
+glama.ai/mcp/servers?query=spotify.

--- a/src/spotify_mcp/__init__.py
+++ b/src/spotify_mcp/__init__.py
@@ -1,7 +1,46 @@
+import os
 import signal
 import sys
 
-from .fastmcp_server import mcp
+from .fastmcp_server import build_http_app, mcp
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _run_stdio() -> None:
+    mcp.run()
+
+
+def _run_http() -> None:
+    """Serve over streamable-HTTP for remote/hosted deploys.
+
+    Config via env: SPOTIFY_MCP_HOST, SPOTIFY_MCP_PORT, SPOTIFY_MCP_STATELESS
+    (required on Modal — see PLAN.md), and SPOTIFY_MCP_BEARER (optional token gate).
+    """
+    host = os.getenv("SPOTIFY_MCP_HOST", "127.0.0.1")
+    port = int(os.getenv("SPOTIFY_MCP_PORT", "8000"))
+    mcp.settings.host = host
+    mcp.settings.port = port
+    mcp.settings.stateless_http = _env_bool("SPOTIFY_MCP_STATELESS")
+
+    bearer = os.getenv("SPOTIFY_MCP_BEARER")
+    if bearer:
+        # Bearer gating needs a custom ASGI wrapper, so run uvicorn ourselves.
+        import uvicorn
+
+        uvicorn.run(
+            build_http_app(bearer_token=bearer),
+            host=host,
+            port=port,
+            log_level=mcp.settings.log_level.lower(),
+        )
+    else:
+        mcp.run(transport="streamable-http")
 
 
 def main() -> None:
@@ -9,8 +48,18 @@ def main() -> None:
     # Handle SIGPIPE gracefully (when client disconnects)
     signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
+    transport = os.getenv("SPOTIFY_MCP_TRANSPORT", "stdio").strip().lower()
+
     try:
-        mcp.run()
+        if transport == "stdio":
+            _run_stdio()
+        elif transport in ("streamable-http", "http"):
+            _run_http()
+        else:
+            raise SystemExit(
+                f"Unknown SPOTIFY_MCP_TRANSPORT={transport!r} "
+                "(expected 'stdio' or 'streamable-http')"
+            )
     except BrokenPipeError:
         # Handle broken pipe gracefully when client disconnects
         sys.exit(0)

--- a/src/spotify_mcp/fastmcp_server.py
+++ b/src/spotify_mcp/fastmcp_server.py
@@ -5,6 +5,7 @@ Clean, simple implementation using FastMCP's automatic features.
 
 from __future__ import annotations
 
+import hmac
 import json
 import logging
 from typing import TYPE_CHECKING, cast
@@ -27,6 +28,8 @@ from spotify_mcp.logging_utils import (
 )
 
 if TYPE_CHECKING:
+    from starlette.types import ASGIApp, Receive, Scope, Send
+
     from spotify_mcp.spotify_types import (
         AlbumObject,
         AlbumRef,
@@ -1360,6 +1363,47 @@ Pagination Best Practices:
 - Stop when you find enough quality matches
 
 Output: Curated list of 15-25 discovered tracks with variety"""
+
+
+# === HTTP TRANSPORT ===
+
+
+def _bearer_guard(app: ASGIApp, token: str) -> ASGIApp:
+    """Wrap an ASGI app so HTTP requests must carry `Authorization: Bearer <token>`.
+
+    Non-http scopes (e.g. lifespan) pass straight through so the streamable-HTTP
+    session manager still starts. Uses a constant-time compare.
+    """
+    expected = b"Bearer " + token.encode()
+
+    async def guarded(scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http":
+            headers = dict(scope.get("headers") or [])
+            provided = headers.get(b"authorization", b"")
+            if not hmac.compare_digest(provided, expected):
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": 401,
+                        "headers": [(b"content-type", b"text/plain; charset=utf-8")],
+                    }
+                )
+                await send({"type": "http.response.body", "body": b"Unauthorized"})
+                return
+        await app(scope, receive, send)
+
+    return guarded
+
+
+def build_http_app(bearer_token: str | None = None) -> ASGIApp:
+    """Build the streamable-HTTP ASGI app, optionally gated by a bearer token.
+
+    Used by the CLI http path and by remote deploy entrypoints (e.g. Modal).
+    """
+    app: ASGIApp = mcp.streamable_http_app()
+    if bearer_token:
+        app = _bearer_guard(app, bearer_token)
+    return app
 
 
 if __name__ == "__main__":

--- a/src/spotify_mcp/spotify_api.py
+++ b/src/spotify_mcp/spotify_api.py
@@ -4,16 +4,17 @@ import logging
 import os
 import tomllib
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import spotipy
 from dotenv import load_dotenv
+from spotipy.cache_handler import (
+    CacheFileHandler,
+    CacheHandler,
+    MemoryCacheHandler,
+)
 from spotipy.oauth2 import SpotifyOAuth
 
 from .utils import normalize_redirect_uri
-
-if TYPE_CHECKING:
-    from spotipy.cache_handler import CacheFileHandler
 
 
 def load_config() -> dict[str, str | None]:
@@ -85,6 +86,47 @@ SCOPES = [
 ]
 
 
+def is_headless() -> bool:
+    """True when there's no interactive browser to complete the OAuth flow.
+
+    Remote/hosted deploys (http transport, or a pre-supplied refresh token) must
+    never try to pop a browser; local stdio installs still get the convenient
+    auto-open flow on first auth.
+    """
+    if os.getenv("SPOTIFY_REFRESH_TOKEN"):
+        return True
+    transport = os.getenv("SPOTIFY_MCP_TRANSPORT", "stdio").strip().lower()
+    return transport in ("streamable-http", "http")
+
+
+def build_cache_handler(scope: str) -> CacheHandler | None:
+    """Pick a token-cache strategy for the current environment.
+
+    Headless deploys can't run the interactive browser OAuth flow and often have
+    an ephemeral filesystem, so we seed the token from a pre-obtained refresh
+    token (`SPOTIFY_REFRESH_TOKEN`) or point at a writable cache file on a
+    persistent volume (`SPOTIFY_CACHE_PATH`). Returns None to fall back to
+    spotipy's default local file cache.
+    """
+    refresh_token = os.getenv("SPOTIFY_REFRESH_TOKEN")
+    if refresh_token:
+        # expires_at=0 forces spotipy to refresh the access token on first use
+        token_info = {
+            "access_token": "",
+            "token_type": "Bearer",
+            "refresh_token": refresh_token,
+            "scope": scope,
+            "expires_at": 0,
+        }
+        return MemoryCacheHandler(token_info=token_info)
+
+    cache_path = os.getenv("SPOTIFY_CACHE_PATH")
+    if cache_path:
+        return CacheFileHandler(cache_path=cache_path)
+
+    return None
+
+
 class Client:
     """Owns Spotify OAuth setup and exposes the authenticated spotipy client.
 
@@ -94,7 +136,7 @@ class Client:
 
     sp: spotipy.Spotify
     auth_manager: SpotifyOAuth
-    cache_handler: CacheFileHandler
+    cache_handler: CacheHandler
     logger: logging.Logger
 
     def __init__(self, logger: logging.Logger | None = None):
@@ -111,6 +153,8 @@ class Client:
                 client_id=CLIENT_ID,
                 client_secret=CLIENT_SECRET,
                 redirect_uri=REDIRECT_URI,
+                open_browser=not is_headless(),
+                cache_handler=build_cache_handler(scope),
             )
 
             self.sp = spotipy.Spotify(auth_manager=auth_manager)

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -53,9 +53,7 @@ class TestBearerGuard:
         inner = _FakeApp()
         guarded = _bearer_guard(inner, "secret")
 
-        sent = await _drive(
-            guarded, _http_scope([(b"authorization", b"Bearer nope")])
-        )
+        sent = await _drive(guarded, _http_scope([(b"authorization", b"Bearer nope")]))
 
         assert sent[0]["status"] == 401
         assert inner.seen == []

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -1,0 +1,156 @@
+"""Tests for streamable-HTTP transport selection and the bearer-auth wrapper."""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+from starlette.applications import Starlette
+
+import spotify_mcp
+from spotify_mcp.fastmcp_server import _bearer_guard, build_http_app
+
+
+class _FakeApp:
+    """Minimal inner ASGI app that records which scope types reach it."""
+
+    def __init__(self):
+        self.seen = []
+
+    async def __call__(self, scope, receive, send):
+        self.seen.append(scope["type"])
+        await send({"type": "passed-through"})
+
+
+async def _drive(app, scope):
+    """Run an ASGI app once and return the messages it sent."""
+    sent = []
+
+    async def receive():
+        return {"type": "http.request"}
+
+    async def send(message):
+        sent.append(message)
+
+    await app(scope, receive, send)
+    return sent
+
+
+def _http_scope(headers):
+    return {"type": "http", "headers": headers}
+
+
+class TestBearerGuard:
+    async def test_rejects_missing_header(self):
+        inner = _FakeApp()
+        guarded = _bearer_guard(inner, "secret")
+
+        sent = await _drive(guarded, _http_scope([]))
+
+        assert sent[0]["status"] == 401
+        assert inner.seen == []
+
+    async def test_rejects_wrong_token(self):
+        inner = _FakeApp()
+        guarded = _bearer_guard(inner, "secret")
+
+        sent = await _drive(
+            guarded, _http_scope([(b"authorization", b"Bearer nope")])
+        )
+
+        assert sent[0]["status"] == 401
+        assert inner.seen == []
+
+    async def test_allows_correct_token(self):
+        inner = _FakeApp()
+        guarded = _bearer_guard(inner, "secret")
+
+        await _drive(guarded, _http_scope([(b"authorization", b"Bearer secret")]))
+
+        assert inner.seen == ["http"]
+
+    async def test_passes_through_non_http_scopes(self):
+        # lifespan must reach the inner app so the session manager can start
+        inner = _FakeApp()
+        guarded = _bearer_guard(inner, "secret")
+
+        await _drive(guarded, {"type": "lifespan", "headers": []})
+
+        assert inner.seen == ["lifespan"]
+
+
+class TestBuildHttpApp:
+    def test_without_bearer_returns_starlette(self):
+        assert isinstance(build_http_app(), Starlette)
+
+    async def test_with_bearer_blocks_unauthorized(self):
+        app = build_http_app(bearer_token="tok")
+
+        sent = await _drive(app, _http_scope([]))
+
+        assert sent[0]["status"] == 401
+
+
+class TestEnvBool:
+    def test_true_values(self, monkeypatch):
+        monkeypatch.setenv("X_FLAG", "Yes")
+        assert spotify_mcp._env_bool("X_FLAG") is True
+
+    def test_false_value(self, monkeypatch):
+        monkeypatch.setenv("X_FLAG", "0")
+        assert spotify_mcp._env_bool("X_FLAG") is False
+
+    def test_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("X_FLAG", raising=False)
+        assert spotify_mcp._env_bool("X_FLAG", default=True) is True
+
+
+class TestTransportDispatch:
+    def test_defaults_to_stdio(self, monkeypatch):
+        monkeypatch.delenv("SPOTIFY_MCP_TRANSPORT", raising=False)
+        stdio, http = MagicMock(), MagicMock()
+        monkeypatch.setattr(spotify_mcp, "_run_stdio", stdio)
+        monkeypatch.setattr(spotify_mcp, "_run_http", http)
+
+        spotify_mcp.main()
+
+        stdio.assert_called_once()
+        http.assert_not_called()
+
+    def test_selects_http(self, monkeypatch):
+        monkeypatch.setenv("SPOTIFY_MCP_TRANSPORT", "streamable-http")
+        stdio, http = MagicMock(), MagicMock()
+        monkeypatch.setattr(spotify_mcp, "_run_stdio", stdio)
+        monkeypatch.setattr(spotify_mcp, "_run_http", http)
+
+        spotify_mcp.main()
+
+        http.assert_called_once()
+        stdio.assert_not_called()
+
+    def test_unknown_transport_raises(self, monkeypatch):
+        monkeypatch.setenv("SPOTIFY_MCP_TRANSPORT", "carrier-pigeon")
+
+        with pytest.raises(SystemExit):
+            spotify_mcp.main()
+
+
+class TestRunHttp:
+    def test_no_bearer_uses_mcp_run(self, monkeypatch):
+        monkeypatch.delenv("SPOTIFY_MCP_BEARER", raising=False)
+        monkeypatch.setenv("SPOTIFY_MCP_PORT", "9001")
+        run = MagicMock()
+        monkeypatch.setattr(spotify_mcp.mcp, "run", run)
+
+        spotify_mcp._run_http()
+
+        run.assert_called_once_with(transport="streamable-http")
+        assert spotify_mcp.mcp.settings.port == 9001
+
+    def test_bearer_runs_uvicorn(self, monkeypatch):
+        monkeypatch.setenv("SPOTIFY_MCP_BEARER", "tok")
+        fake_uvicorn = MagicMock()
+        monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+
+        spotify_mcp._run_http()
+
+        fake_uvicorn.run.assert_called_once()

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -62,15 +62,26 @@ class TestConsistencyWithPyproject:
 
 
 class TestEnvVarsMatchCode:
-    def test_server_json_declares_exactly_the_vars_the_code_reads(
+    REQUIRED_CORE = {
+        "SPOTIFY_CLIENT_ID",
+        "SPOTIFY_CLIENT_SECRET",
+        "SPOTIFY_REDIRECT_URI",
+    }
+
+    def test_server_json_only_declares_vars_the_code_reads(
         self, server_json: dict
     ) -> None:
+        # The stdio manifest may omit optional remote-deploy vars (refresh token,
+        # cache path, transport knobs), but it must never declare a var the code
+        # doesn't read, and must declare the required core vars.
         declared = {
             ev["name"] for ev in server_json["packages"][0]["environmentVariables"]
         }
-        source = (ROOT / "src" / "spotify_mcp" / "spotify_api.py").read_text()
+        src_dir = ROOT / "src" / "spotify_mcp"
+        source = "\n".join(p.read_text() for p in sorted(src_dir.glob("*.py")))
         used = set(re.findall(r'os\.getenv\(\s*"(SPOTIFY_[A-Z_]+)"', source))
-        assert declared == used
+        assert declared <= used
+        assert self.REQUIRED_CORE <= declared
 
     def test_required_secrets_are_flagged(self, server_json: dict) -> None:
         by_name = {

--- a/tests/test_spotify_api.py
+++ b/tests/test_spotify_api.py
@@ -5,9 +5,15 @@ from unittest.mock import patch
 
 import pytest
 import spotipy
+from spotipy.cache_handler import CacheFileHandler, MemoryCacheHandler
 from spotipy.exceptions import SpotifyOauthError
 
-from spotify_mcp.spotify_api import Client, load_config
+from spotify_mcp.spotify_api import (
+    Client,
+    build_cache_handler,
+    is_headless,
+    load_config,
+)
 
 
 class TestLoadConfig:
@@ -95,3 +101,66 @@ class TestSpotifyClient:
     def test_raises_on_missing_credentials(self):
         with pytest.raises(SpotifyOauthError):
             Client()
+
+
+class TestHeadlessAuth:
+    """Headless/remote OAuth: no browser, token seeded out-of-band."""
+
+    def test_is_headless_false_for_local_stdio(self, monkeypatch):
+        monkeypatch.delenv("SPOTIFY_REFRESH_TOKEN", raising=False)
+        monkeypatch.delenv("SPOTIFY_MCP_TRANSPORT", raising=False)
+        assert is_headless() is False
+
+    def test_is_headless_true_with_refresh_token(self, monkeypatch):
+        monkeypatch.setenv("SPOTIFY_REFRESH_TOKEN", "rt")
+        assert is_headless() is True
+
+    def test_is_headless_true_with_http_transport(self, monkeypatch):
+        monkeypatch.delenv("SPOTIFY_REFRESH_TOKEN", raising=False)
+        monkeypatch.setenv("SPOTIFY_MCP_TRANSPORT", "streamable-http")
+        assert is_headless() is True
+
+    def test_refresh_token_seeds_memory_handler(self, monkeypatch):
+        monkeypatch.setenv("SPOTIFY_REFRESH_TOKEN", "my-refresh")
+        monkeypatch.delenv("SPOTIFY_CACHE_PATH", raising=False)
+
+        handler = build_cache_handler("scope-a,scope-b")
+
+        assert isinstance(handler, MemoryCacheHandler)
+        cached = handler.get_cached_token()
+        assert cached["refresh_token"] == "my-refresh"
+        assert cached["scope"] == "scope-a,scope-b"
+        assert cached["expires_at"] == 0
+
+    def test_cache_path_uses_file_handler(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("SPOTIFY_REFRESH_TOKEN", raising=False)
+        monkeypatch.setenv("SPOTIFY_CACHE_PATH", str(tmp_path / ".cache"))
+
+        handler = build_cache_handler("scope")
+
+        assert isinstance(handler, CacheFileHandler)
+
+    def test_no_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.delenv("SPOTIFY_REFRESH_TOKEN", raising=False)
+        monkeypatch.delenv("SPOTIFY_CACHE_PATH", raising=False)
+
+        assert build_cache_handler("scope") is None
+
+    def test_client_disables_browser_when_headless(self, monkeypatch):
+        monkeypatch.setenv("SPOTIFY_REFRESH_TOKEN", "rt")
+
+        with patch("spotify_mcp.spotify_api.SpotifyOAuth") as mock_oauth:
+            Client()
+
+        kwargs = mock_oauth.call_args.kwargs
+        assert kwargs["open_browser"] is False
+        assert isinstance(kwargs["cache_handler"], MemoryCacheHandler)
+
+    def test_client_enables_browser_for_local(self, monkeypatch):
+        monkeypatch.delenv("SPOTIFY_REFRESH_TOKEN", raising=False)
+        monkeypatch.delenv("SPOTIFY_MCP_TRANSPORT", raising=False)
+
+        with patch("spotify_mcp.spotify_api.SpotifyOAuth") as mock_oauth:
+            Client()
+
+        assert mock_oauth.call_args.kwargs["open_browser"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -1099,6 +1099,7 @@ dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "python-dotenv" },
     { name = "spotipy" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -1120,6 +1121,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.1" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "spotipy", specifier = ">=2.26.0" },
+    { name = "uvicorn", specifier = ">=0.35.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
adds an optional streamable-HTTP transport so the server can be hosted remotely (homelab, Modal, etc.) instead of only running locally over stdio. stdio stays the default — http is fully opt-in via env. also lands the competitive research that motivated this plus a [PLAN.md](PLAN.md) deployment guide.

- `SPOTIFY_MCP_TRANSPORT=streamable-http` serves over HTTP (`SPOTIFY_MCP_HOST`/`PORT`/`STATELESS` knobs); stdio remains the zero-config default
- headless OAuth: seed `SPOTIFY_REFRESH_TOKEN` (in-memory) or `SPOTIFY_CACHE_PATH` (file on a volume) so hosted deploys never need a browser — local stdio still auto-opens one
- optional `SPOTIFY_MCP_BEARER` gates the endpoint with a constant-time bearer check; otherwise keep it behind a private network
- [`deploy/modal_app.py`](deploy/modal_app.py) for a one-command Modal deploy (stateless, since Modal's 150s request cap breaks stateful SSE) + Dockerfile EXPOSE/env notes
- [research/spotify-mcp-landscape.md](research/spotify-mcp-landscape.md): survey of other Spotify MCPs — most are stdio-only, so remote hosting is a real differentiator
- adds `uvicorn` as a direct dep (used for the bearer path)

to test:
- `SPOTIFY_MCP_TRANSPORT=streamable-http uv run spotify-mcp` then `claude mcp add --transport http spotify http://127.0.0.1:8000/mcp` → list tools, run a search
- set `SPOTIFY_MCP_BEARER=…` and confirm requests without the header get a 401