### PR TITLE
Return the artist when Spotify withholds its top tracks

### DIFF
--- a/src/spotify_mcp/fastmcp_server.py
+++ b/src/spotify_mcp/fastmcp_server.py
@@ -793,6 +793,28 @@ def get_track_info(track_ids: str | list[str]) -> TrackList:
         raise convert_spotify_error(e) from e
 
 
+# /artists/{id}/top-tracks is withheld from restricted apps: it answers 403
+# rather than the 400/404 that `with_fallback` treats as a regime miss, and no
+# alternative path serves it. Degrade to no top tracks instead of failing the
+# whole tool, the same way the stripped `followers`/`popularity` fields do.
+_TOP_TRACKS_WITHHELD_STATUSES = frozenset({401, 403})
+
+
+def _artist_top_tracks_or_empty(artist_id: str) -> dict:
+    """Read an artist's top tracks, returning `{}` when Spotify withholds them."""
+    try:
+        top_tracks: dict = spotify_client.artist_top_tracks(artist_id)
+        return top_tracks
+    except SpotifyException as e:
+        if e.http_status not in _TOP_TRACKS_WITHHELD_STATUSES:
+            raise
+        logger.info(
+            f"🎤 Top tracks withheld for artist {artist_id} "
+            f"(HTTP {e.http_status}); returning artist without them"
+        )
+        return {}
+
+
 @mcp.tool(
     title="Get Artist Info",
     annotations=ToolAnnotations(
@@ -807,12 +829,14 @@ def get_artist_info(artist_id: str) -> ArtistInfo:
     Args:
         artist_id: Spotify artist ID
     Returns:
-        ArtistInfo with the artist and their top tracks
+        ArtistInfo with the artist and, where the app is allowed to read them,
+        their top tracks. `top_tracks` is empty rather than an error when
+        Spotify withholds that endpoint.
     """
     try:
         logger.info(f"🎤 Getting artist info: {artist_id}")
         result: ArtistObject = spotify_client.artist(artist_id)
-        top_tracks = spotify_client.artist_top_tracks(artist_id)
+        top_tracks = _artist_top_tracks_or_empty(artist_id)
 
         followers = result.get("followers") or {}
         artist = Artist(

--- a/tests/test_fastmcp_tools.py
+++ b/tests/test_fastmcp_tools.py
@@ -369,6 +369,33 @@ class TestGetArtistInfo:
         with pytest.raises(ValueError):
             get_artist_info("badid")
 
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_withheld_top_tracks_still_returns_artist(
+        self, mock_spotify_api, sample_artist_data, status
+    ):
+        """Restricted apps get 403 from /top-tracks; the artist must still come back."""
+        mock_spotify_api.artist.return_value = sample_artist_data
+        mock_spotify_api.artist_top_tracks.side_effect = SpotifyException(
+            status, -1, "Forbidden"
+        )
+
+        result = get_artist_info("0gxyHStUsqpMadRV0Di1Qt")
+
+        assert result.artist.name == "Rick Astley"
+        assert result.top_tracks == []
+
+    def test_other_top_tracks_errors_still_raise(
+        self, mock_spotify_api, sample_artist_data
+    ):
+        """A 500 is not a permissions boundary and must not be swallowed."""
+        mock_spotify_api.artist.return_value = sample_artist_data
+        mock_spotify_api.artist_top_tracks.side_effect = SpotifyException(
+            500, -1, "Server Error"
+        )
+
+        with pytest.raises(ValueError):
+            get_artist_info("0gxyHStUsqpMadRV0Di1Qt")
+
 
 class TestGetPlaylistInfo:
     def test_success(self, mock_spotify_api, sample_playlist_data):


### PR DESCRIPTION
## Problem

`get_artist_info` fails for **every** artist on a restricted app, not just for unusual IDs.

It makes two upstream calls, and the second one is withheld:

```
GET /v1/artists/5zbSsk4Qg514fYzb3KhQX7/top-tracks?country=US -> 403 Forbidden
GET /v1/artists/5zbSsk4Qg514fYzb3KhQX7                       -> 200 OK
```

Because the 403 propagates, the tool returns an error even though the artist was read successfully:

```
Error executing tool get_artist_info: Playback is restricted for this content [playback_restricted]
```

I first hit this on an ID I assumed was stale, but it reproduces on a known-good artist, and the `spotify://artist/{id}` resource returns that same artist fine — precisely because it omits the top-tracks call. So the artist data is available; only the extra call is not.

`with_fallback` can't cover this: `_REGIME_MISS_STATUSES` is `{400, 404, 405, 410}`, and there is no alternative path that serves top tracks for a restricted app.

## Fix

Treat a withheld top-tracks endpoint the way the stripped `followers`/`popularity` fields are already treated — degrade rather than throw. `top_tracks` comes back empty, the artist comes back populated. Any status that isn't a permissions boundary (401/403) still raises, so a 500 is not silently swallowed.

## Testing

- `ruff check`, `ruff format --check`, `mypy src/`, `bandit -r src/` all clean
- `pytest`: 172 passed (3 new — 401 and 403 degrade, 500 still raises)
- Live-verified against the real API on a restricted app, which is where the offline suite is blind:

```
OK  Major Sunburn: name='Major Sunburn' top_tracks=0 followers=None
OK  Major Tom:     name='Major Tom'     top_tracks=0 followers=None
```

Both previously failed outright.

## Note

No `CHANGELOG.md` entry here deliberately — I have a few sibling fixes in flight and they'd all conflict on the same lines. Happy to add one to whichever lands first, or to all of them if you'd rather.