### PR TITLE
Retry search at the page-size cap Spotify actually allows

### DIFF
--- a/src/spotify_mcp/fastmcp_server.py
+++ b/src/spotify_mcp/fastmcp_server.py
@@ -615,7 +615,10 @@ def search_music(
     Args:
         query: Search query
         qtype: Type ('track', 'album', 'artist', 'playlist')
-        limit: Max results per page (1-50, default 10)
+        limit: Max results per page (1-50, default 10). Spotify caps search at 10
+            per page for restricted apps and rejects anything larger; a larger
+            limit is retried at the cap rather than failing. Check the returned
+            `limit` for what was actually served, and use `offset` to go deeper.
         offset: Number of results to skip for pagination (default 0)
         year: Filter by year (e.g., '2024')
         year_range: Filter by year range (e.g., '2020-2024')
@@ -630,7 +633,7 @@ def search_music(
     Example: query='love', year='2024', genre='pop' searches for 'love year:2024 genre:pop'
     """
     try:
-        limit = max(1, min(50, limit))
+        limit = max(1, min(spotify_api.SEARCH_LIMIT_MAX, limit))
 
         # Build filtered query
         filters = []
@@ -650,8 +653,8 @@ def search_music(
         logger.info(
             f"🔍 Searching {qtype}s: '{full_query}' (limit={limit}, offset={offset})"
         )
-        result = spotify_client.search(
-            q=full_query, type=qtype, limit=limit, offset=offset
+        result = spotify_api.search(
+            spotify_client, full_query, qtype=qtype, limit=limit, offset=offset
         )
 
         tracks = []

--- a/src/spotify_mcp/spotify_api.py
+++ b/src/spotify_mcp/spotify_api.py
@@ -273,3 +273,48 @@ def remove_saved_tracks(sp: spotipy.Spotify, track_ids: list[str]) -> None:
         ),
         lambda: sp.current_user_saved_tracks_delete(tracks=ids),
     )
+
+
+# Search page size is regime-dependent: legacy apps get 50, restricted apps get
+# 10 and answer 400 "Invalid limit" for anything above it. Which one we are is
+# not introspectable, so discover the ceiling on the first rejection and reuse it
+# for the life of the process, the same way `with_fallback` caches a family.
+_RESTRICTED_SEARCH_LIMIT = 10
+SEARCH_LIMIT_MAX = 50
+_search_limit_max: int = SEARCH_LIMIT_MAX
+
+
+def search_limit_ceiling() -> int:
+    """The largest search `limit` known to be accepted for this app."""
+    return _search_limit_max
+
+
+def search(
+    sp: spotipy.Spotify, query: str, *, qtype: str, limit: int, offset: int
+) -> dict:
+    """Search, retrying at the restricted page size if the limit is rejected."""
+    global _search_limit_max
+
+    capped = min(limit, _search_limit_max)
+    try:
+        result: dict = sp.search(q=query, type=qtype, limit=capped, offset=offset)
+        return result
+    except SpotifyException as e:
+        # Only a limit that is too large earns a retry. A 400 for a malformed
+        # query must still surface.
+        too_large = capped > _RESTRICTED_SEARCH_LIMIT
+        if (
+            e.http_status != 400
+            or "limit" not in (e.msg or "").lower()
+            or not too_large
+        ):
+            raise
+        _search_limit_max = _RESTRICTED_SEARCH_LIMIT
+        logging.getLogger(__name__).info(
+            f"Spotify rejected search limit {capped}; "
+            f"this app caps search at {_RESTRICTED_SEARCH_LIMIT} results per page"
+        )
+        retried: dict = sp.search(
+            q=query, type=qtype, limit=_RESTRICTED_SEARCH_LIMIT, offset=offset
+        )
+        return retried

--- a/tests/test_spotify_api.py
+++ b/tests/test_spotify_api.py
@@ -8,6 +8,7 @@ import spotipy
 from spotipy import SpotifyException
 from spotipy.exceptions import SpotifyOauthError
 
+import spotify_mcp.spotify_api as spotify_api
 from spotify_mcp.spotify_api import (
     RETRY_STATUS_CODES,
     Client,
@@ -153,6 +154,65 @@ class TestWithFallback:
             with_fallback("fam", restricted, legacy)
 
         legacy.assert_not_called()
+
+
+class TestSearchLimitCeiling:
+    """Restricted apps cap search at 10 per page and 400 above it. No fake
+    upstream reports that cap, so it is asserted against a real rejection."""
+
+    INVALID_LIMIT = SpotifyException(400, -1, "Invalid limit, reason: None")
+
+    @pytest.fixture(autouse=True)
+    def _reset_ceiling(self):
+        spotify_api._search_limit_max = spotify_api.SEARCH_LIMIT_MAX
+        yield
+        spotify_api._search_limit_max = spotify_api.SEARCH_LIMIT_MAX
+
+    def test_passes_the_requested_limit_through_when_accepted(self):
+        sp = MagicMock()
+        sp.search.return_value = {"tracks": {"items": []}}
+
+        spotify_api.search(sp, "trance", qtype="track", limit=50, offset=0)
+
+        sp.search.assert_called_once_with(q="trance", type="track", limit=50, offset=0)
+
+    def test_retries_at_the_restricted_cap(self):
+        sp = MagicMock()
+        sp.search.side_effect = [self.INVALID_LIMIT, {"tracks": {"items": []}}]
+
+        result = spotify_api.search(sp, "trance", qtype="track", limit=20, offset=0)
+
+        assert result == {"tracks": {"items": []}}
+        assert [c.kwargs["limit"] for c in sp.search.call_args_list] == [20, 10]
+
+    def test_remembers_the_cap_for_later_calls(self):
+        sp = MagicMock()
+        sp.search.side_effect = [self.INVALID_LIMIT, {"a": 1}, {"a": 2}]
+
+        spotify_api.search(sp, "trance", qtype="track", limit=20, offset=0)
+        spotify_api.search(sp, "goa", qtype="track", limit=50, offset=0)
+
+        # the oversized limit is not attempted a second time
+        assert [c.kwargs["limit"] for c in sp.search.call_args_list] == [20, 10, 10]
+        assert spotify_api.search_limit_ceiling() == 10
+
+    def test_a_limit_already_at_the_cap_is_not_retried(self):
+        sp = MagicMock()
+        sp.search.side_effect = self.INVALID_LIMIT
+
+        with pytest.raises(SpotifyException):
+            spotify_api.search(sp, "trance", qtype="track", limit=10, offset=0)
+
+        assert sp.search.call_count == 1
+
+    def test_an_unrelated_400_is_not_retried(self):
+        sp = MagicMock()
+        sp.search.side_effect = SpotifyException(400, -1, "Invalid query")
+
+        with pytest.raises(SpotifyException):
+            spotify_api.search(sp, "", qtype="track", limit=20, offset=0)
+
+        assert sp.search.call_count == 1
 
 
 class TestLibraryWrites:


### PR DESCRIPTION
## Problem

`search_music` advertises `limit` 1-50 and clamps to 50, but a restricted app is capped at **10** results per page and rejects anything larger outright:

```
GET /v1/search?q=trance&type=track&limit=10 -> 200 OK, 10 items
GET /v1/search?q=trance&type=track&limit=11 -> 400 Invalid limit
GET /v1/search?q=trance&type=track&limit=50 -> 400 Invalid limit
```

So every call with `limit` between 11 and 50 fails, rather than returning fewer results. That includes the example the `create_mood_playlist` prompt tells clients to run:

> `search_music("upbeat pop", limit=20, offset=0)` then `offset=20` for more

`CLAUDE.md`'s own watch notes already anticipated this — *"search_music max drops 50 → 10 (our schema still advertises 50)"* — this makes the code match.

## Fix

The ceiling is regime-dependent and not introspectable, so discover it the same way `with_fallback` discovers a family: attempt the requested size, and on a limit-specific 400, retry at 10 and remember it for the life of the process. Legacy apps keep their 50 and never pay a retry.

Guarded against over-reach:
- a 400 that isn't about the limit still raises (a malformed query shouldn't silently retry)
- a request already at the cap still raises rather than looping
- the cap is cached, so only the first oversized call costs an extra round trip

The tool docstring now says the limit may be capped and points callers at the returned `limit` for what was actually served.

## Testing

- `ruff check`, `ruff format --check`, `mypy src/`, `bandit -r src/` all clean
- `pytest`: 174 passed (5 new, covering pass-through, retry, caching, at-cap, and unrelated-400)
- Live-verified, which is where the offline suite is blind:

```
ceiling before: 50
limit=20 -> returned 10 items, served limit=10, total=19
ceiling after: 10
limit=50 -> returned 10 items (no second rejection)
```

Previously `limit=20` was a hard 400.

## Note

No `CHANGELOG.md` entry deliberately — sibling fixes are in flight and would all conflict on the same lines. Happy to add one to whichever lands first.