### PR TITLE
Fill total_tracks when Spotify strips it from the playlist object

### DIFF
--- a/src/spotify_mcp/fastmcp_server.py
+++ b/src/spotify_mcp/fastmcp_server.py
@@ -830,6 +830,13 @@ def get_artist_info(artist_id: str) -> ArtistInfo:
         raise convert_spotify_error(e) from e
 
 
+def _total_tracks(playlist_id: str, reported: object) -> int | None:
+    """Prefer the count Spotify reported, else read it off the items endpoint."""
+    if isinstance(reported, int):
+        return reported
+    return spotify_api.playlist_total(spotify_client, playlist_id)
+
+
 @mcp.tool(
     title="Get Playlist Info",
     annotations=ToolAnnotations(
@@ -864,7 +871,7 @@ def get_playlist_info(playlist_id: str) -> Playlist:
             owner=owner.get("display_name"),
             description=result.get("description"),
             tracks=None,  # No tracks - use get_playlist_tracks
-            total_tracks=tracks.get("total"),
+            total_tracks=_total_tracks(playlist_id, tracks.get("total")),
             public=result.get("public"),
         )
 
@@ -1607,7 +1614,7 @@ def playlist_resource(playlist_id: str) -> str:
             id=result["id"],
             owner=owner.get("display_name"),
             description=result.get("description"),
-            total_tracks=tracks.get("total"),
+            total_tracks=_total_tracks(playlist_id, tracks.get("total")),
             public=result.get("public"),
         ).model_dump_json()
     except Exception as e:

--- a/src/spotify_mcp/spotify_api.py
+++ b/src/spotify_mcp/spotify_api.py
@@ -189,6 +189,19 @@ def playlist_items(
     )
 
 
+def playlist_total(sp: spotipy.Spotify, playlist_id: str) -> int | None:
+    """How many entries a playlist holds, or None if Spotify won't say.
+
+    `playlist(fields="tracks.total")` is the obvious source and does not work:
+    restricted apps get the field stripped, so it comes back absent (asking for
+    it alone yields a bare `{}`). A one-item page of the items endpoint still
+    reports the real `total`, so read it from there.
+    """
+    page = playlist_items(sp, playlist_id, limit=1, offset=0)
+    total = page.get("total")
+    return total if isinstance(total, int) else None
+
+
 def create_playlist(
     sp: spotipy.Spotify, name: str, description: str, public: bool
 ) -> dict:

--- a/tests/test_fastmcp_tools.py
+++ b/tests/test_fastmcp_tools.py
@@ -382,6 +382,19 @@ class TestGetPlaylistInfo:
             "37i9dQZF1DX0XUsuxWHRQd",
             fields="id,name,description,owner,public,tracks.total",
         )
+        # a reported count is trusted, so no extra lookup is made
+        mock_spotify_api._get.assert_not_called()
+
+    def test_falls_back_to_the_items_endpoint_for_a_stripped_count(
+        self, mock_spotify_api, sample_playlist_data
+    ):
+        """Restricted apps get `tracks.total` stripped; total_tracks must still fill."""
+        mock_spotify_api.playlist.return_value = {**sample_playlist_data, "tracks": {}}
+        mock_spotify_api._get.return_value = {"items": [], "total": 65}
+
+        result = get_playlist_info("37i9dQZF1DX0XUsuxWHRQd")
+
+        assert result.total_tracks == 65
 
     def test_spotify_error(self, mock_spotify_api):
         mock_spotify_api.playlist.side_effect = SPOTIFY_ERROR
@@ -855,6 +868,16 @@ class TestResources:
         result = json.loads(playlist_resource("pl1"))
 
         assert result["name"] == "RapCaviar"
+
+    def test_playlist_resource_fills_a_stripped_count(
+        self, mock_spotify_api, sample_playlist_data
+    ):
+        mock_spotify_api.playlist.return_value = {**sample_playlist_data, "tracks": {}}
+        mock_spotify_api._get.return_value = {"items": [], "total": 65}
+
+        result = json.loads(playlist_resource("pl1"))
+
+        assert result["total_tracks"] == 65
 
     def test_artist_resource(self, mock_spotify_api, sample_artist_data):
         mock_spotify_api.artist.return_value = sample_artist_data


### PR DESCRIPTION
> **Rescoped.** This originally also changed `get_playlist_tracks`, which duplicated #17 / #18. That part is removed — see the note at the bottom.

## Problem

`get_playlist_info` and `playlist_resource` both report `total_tracks: null`, even for a 65-track playlist.

Both ask for the count via `playlist(fields="id,name,description,owner,public,tracks.total")`, and a restricted app doesn't get that field back. Requesting it on its own makes that obvious:

```
sp.playlist(pid, fields="tracks.total")  -> {}
sp.playlist(pid)["tracks"]["total"]      -> None
sp._get(f"playlists/{pid}/items", limit=1, offset=0)["total"] -> 65   # correct
```

The rest of the `fields` list comes through fine — it's only `tracks.total` that's stripped.

## Fix

Read the count off a one-item page of the items endpoint when the playlist object withholds it.

- A reported count is trusted as-is, so the extra request only happens when the field is genuinely missing — legacy apps pay nothing.
- Both call sites go through one helper, so they can't drift apart.

## Testing

- `ruff check`, `ruff format --check`, `mypy src/`, `bandit -r src/` all clean
- `pytest`: 171 passed (2 new — one per call site — plus an assertion that a reported count causes no extra lookup)
- Live-verified on a 65-track playlist, which is where the offline suite is blind:

```
get_playlist_info total_tracks: 65
playlist_resource total_tracks: 65
```

Both previously returned `null`.

## Overlap with #18

I opened this before spotting #17 and #18. #18 fixes the same stripped field for `get_playlist_tracks`' pagination total, and does it the same way. To avoid competing with it:

- `get_playlist_tracks` is **left untouched** here — #18 owns that call site.
- Only `get_playlist_info` and `playlist_resource` are changed, which #18 doesn't touch, so they'd still report `null` after it merges.

There's a small cosmetic redundancy if both land: #18 reads the total inline, this adds a `spotify_api.playlist_total()` helper. Happy to rebase on top of #18 and have `get_playlist_tracks` use the helper too, if you'd prefer one source for it — just say which order you want them in.

`get_user_playlists` is deliberately left alone: filling counts there would mean one request per playlist on a list endpoint.

## Note

No `CHANGELOG.md` entry deliberately — I have sibling fixes open (#19, #20) and they'd all conflict on the same lines. Happy to add one to whichever lands first.