### PR TITLE
Fall back to per-track reads when batching is withheld

### DIFF
--- a/src/spotify_mcp/fastmcp_server.py
+++ b/src/spotify_mcp/fastmcp_server.py
@@ -770,7 +770,10 @@ def get_track_info(track_ids: str | list[str]) -> TrackList:
         TrackList with 'tracks' containing track metadata including release_date.
         For single ID, returns {'tracks': [track]}.
 
-    Note: Batch lookup is much more efficient - 50 tracks = 1 API call instead of 50.
+    Note: Batch lookup is much more efficient where it is available - 50 tracks
+    in 1 API call instead of 50. Spotify withholds the batch endpoint from some
+    apps, in which case this transparently falls back to one request per track,
+    so the result is the same either way.
     """
     try:
         # Normalize to list
@@ -781,12 +784,11 @@ def get_track_info(track_ids: str | list[str]) -> TrackList:
 
         logger.info(f"🎵 Getting track info for {len(ids)} track(s)")
 
-        if len(ids) == 1:
-            result = spotify_client.track(ids[0])
-            tracks = [parse_track(result)]
-        else:
-            result = spotify_client.tracks(ids)
-            tracks = [parse_track(item) for item in result.get("tracks", []) if item]
+        tracks = [
+            parse_track(cast("TrackObject", item))
+            for item in spotify_api.get_tracks(spotify_client, ids)
+            if item
+        ]
 
         return TrackList(tracks=tracks)
     except SpotifyException as e:

--- a/src/spotify_mcp/spotify_api.py
+++ b/src/spotify_mcp/spotify_api.py
@@ -177,6 +177,46 @@ def with_fallback[T](
         return result
 
 
+# /v1/tracks?ids= is withheld from restricted apps (403) while /v1/tracks/{id}
+# still works, so batching has to degrade to per-id reads. This is a different
+# shape from `with_fallback`: there is no alternative batch path to swap in, only
+# a different number of requests. Remember the answer so the 403 is paid once per
+# process instead of on every call.
+_BATCH_WITHHELD_STATUSES = frozenset({401, 403})
+_batch_tracks_withheld = False
+
+
+def batch_tracks_withheld() -> bool:
+    """Whether this app has been found unable to read tracks in batches."""
+    return _batch_tracks_withheld
+
+
+def get_tracks(sp: spotipy.Spotify, track_ids: list[str]) -> list[dict]:
+    """Read several tracks, per-id if the batch endpoint is withheld."""
+    global _batch_tracks_withheld
+
+    ids = [to_id(t) for t in track_ids]
+    # One id never needs the batch route, and asking for it would trade a working
+    # request for a guaranteed 403 on restricted apps.
+    if len(ids) == 1:
+        return [sp.track(ids[0])]
+
+    if not _batch_tracks_withheld:
+        try:
+            result = sp.tracks(ids)
+            return [t for t in (result.get("tracks") or []) if t]
+        except SpotifyException as e:
+            if e.http_status not in _BATCH_WITHHELD_STATUSES:
+                raise
+            _batch_tracks_withheld = True
+            logging.getLogger(__name__).info(
+                f"Spotify withheld batch track reads (HTTP {e.http_status}); "
+                f"falling back to one request per track"
+            )
+
+    return [sp.track(i) for i in ids]
+
+
 def playlist_items(
     sp: spotipy.Spotify, playlist_id: str, *, limit: int, offset: int
 ) -> dict:

--- a/tests/test_spotify_api.py
+++ b/tests/test_spotify_api.py
@@ -8,10 +8,12 @@ import spotipy
 from spotipy import SpotifyException
 from spotipy.exceptions import SpotifyOauthError
 
+import spotify_mcp.spotify_api as spotify_api
 from spotify_mcp.spotify_api import (
     RETRY_STATUS_CODES,
     Client,
     _legacy_families,
+    get_tracks,
     load_config,
     remove_saved_tracks,
     save_tracks,
@@ -153,6 +155,84 @@ class TestWithFallback:
             with_fallback("fam", restricted, legacy)
 
         legacy.assert_not_called()
+
+
+class TestGetTracks:
+    """Batch track reads are withheld from restricted apps (403) while single
+    reads work. No fake upstream reports that, so it is asserted directly."""
+
+    FORBIDDEN = SpotifyException(403, -1, "Forbidden")
+
+    @pytest.fixture(autouse=True)
+    def _reset_withheld(self):
+        spotify_api._batch_tracks_withheld = False
+        yield
+        spotify_api._batch_tracks_withheld = False
+
+    def test_a_single_id_never_uses_the_batch_route(self):
+        sp = MagicMock()
+        sp.track.return_value = {"id": "t1"}
+
+        assert get_tracks(sp, ["t1"]) == [{"id": "t1"}]
+
+        sp.track.assert_called_once_with("t1")
+        sp.tracks.assert_not_called()
+
+    def test_batches_when_allowed(self):
+        sp = MagicMock()
+        sp.tracks.return_value = {"tracks": [{"id": "t1"}, {"id": "t2"}]}
+
+        assert get_tracks(sp, ["t1", "t2"]) == [{"id": "t1"}, {"id": "t2"}]
+
+        sp.tracks.assert_called_once_with(["t1", "t2"])
+        sp.track.assert_not_called()
+
+    def test_drops_null_entries_from_a_batch(self):
+        sp = MagicMock()
+        sp.tracks.return_value = {"tracks": [{"id": "t1"}, None]}
+
+        assert get_tracks(sp, ["t1", "gone"]) == [{"id": "t1"}]
+
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_falls_back_to_per_id_reads_when_withheld(self, status):
+        sp = MagicMock()
+        sp.tracks.side_effect = SpotifyException(status, -1, "Forbidden")
+        sp.track.side_effect = [{"id": "t1"}, {"id": "t2"}]
+
+        assert get_tracks(sp, ["t1", "t2"]) == [{"id": "t1"}, {"id": "t2"}]
+
+        assert [c.args[0] for c in sp.track.call_args_list] == ["t1", "t2"]
+
+    def test_remembers_that_batching_is_withheld(self):
+        sp = MagicMock()
+        sp.tracks.side_effect = self.FORBIDDEN
+        sp.track.side_effect = [{"id": "t1"}, {"id": "t2"}, {"id": "t3"}, {"id": "t4"}]
+
+        get_tracks(sp, ["t1", "t2"])
+        get_tracks(sp, ["t3", "t4"])
+
+        # the 403 is paid once, not on every call
+        assert sp.tracks.call_count == 1
+        assert sp.track.call_count == 4
+        assert spotify_api.batch_tracks_withheld() is True
+
+    def test_other_batch_errors_propagate(self):
+        sp = MagicMock()
+        sp.tracks.side_effect = SpotifyException(500, -1, "Server Error")
+
+        with pytest.raises(SpotifyException):
+            get_tracks(sp, ["t1", "t2"])
+
+        sp.track.assert_not_called()
+        assert spotify_api.batch_tracks_withheld() is False
+
+    def test_accepts_uris_as_well_as_ids(self):
+        sp = MagicMock()
+        sp.tracks.return_value = {"tracks": [{"id": "t1"}, {"id": "t2"}]}
+
+        get_tracks(sp, ["spotify:track:t1", "t2"])
+
+        sp.tracks.assert_called_once_with(["t1", "t2"])
 
 
 class TestLibraryWrites:


### PR DESCRIPTION
## Problem

`get_track_info` fails for two or more IDs on a restricted app.

Anything longer than one ID goes through `/v1/tracks?ids=`, which is withheld — while the single-track route works fine for those exact same IDs:

```
GET /v1/tracks/?ids=6ADPS6h7kuqZwqekUrLTEp,7AvWmlcIj7LhwnVqNT4UYa -> 403 Forbidden
GET /v1/tracks/6ADPS6h7kuqZwqekUrLTEp                             -> 200 OK
GET /v1/tracks/7AvWmlcIj7LhwnVqNT4UYa                             -> 200 OK
```

The failure boundary sits exactly on the `len(ids) == 1` branch, which makes it easy to miss:

| call | result |
|---|---|
| `get_track_info("6ADPS...")` | works |
| `get_track_info(["6ADPS..."])` | works |
| `get_track_info(["6ADPS...", "7AvWm..."])` | **`playback_restricted`** |

So the batching the docstring advertises — *"50 tracks = 1 API call instead of 50"* — isn't merely slower than promised, it's unavailable, and simply asking for two tracks errors out. I found this trying to put two track IDs in one request and assuming I'd hit a rate limit or a bad ID.

## Fix

`with_fallback` doesn't fit here: there's no alternative batch path to swap in, only a different number of requests. So try the batch, and on 401/403 degrade to one request per track.

- The decision is remembered for the life of the process, so the 403 is paid **once** rather than on every call.
- A single ID keeps using the single-track route, so it never provokes the 403 in the first place.
- Any other status (e.g. 500) still raises rather than silently fanning out into N requests.
- Null entries are dropped from a batch result, matching the previous behaviour.

Callers see no difference beyond latency, which is why this belongs in `spotify_api` rather than in each caller. The docstring now says batching may fall back instead of promising something the app may not be able to do.

## Testing

- `ruff check`, `ruff format --check`, `mypy src/`, `bandit -r src/` all clean
- `pytest`: 177 passed (8 new — single-ID never batches, batch when allowed, null entries dropped, 401 and 403 both degrade, the decision is cached, other statuses propagate, URIs accepted)
- Live-verified on a restricted app, which is where the offline suite is blind:

```
withheld before: False
3 ids -> 3 tracks:
   Und dann kommt ein Mensch — Major Sunburn
   Was Ist Freundschaft Wert (Major Sunburn Harmony Edit) — By York
   Was ist die Freundschaft wert — MC Crome
withheld after: True
2 ids again -> 2 tracks (no second 403)
single string -> 1 track: Und dann kommt ein Mensch
```

The 3-ID call previously failed outright.

## Relationship to my other PRs

Independent of #19, #20 and #21 — no shared lines, any merge order works. It's the same *class* of defect as #19 (`get_artist_info`): a withheld endpoint inside a tool taking the whole tool down rather than degrading. If you'd prefer these consolidated into one "degrade instead of failing on withheld endpoints" PR, happy to do that.

## Note

No `CHANGELOG.md` entry deliberately — sibling fixes would all conflict on the same lines. Happy to add one to whichever lands first.