### PR TITLE
Confirm a playback action landed before returning the state

### DIFF
--- a/src/spotify_mcp/fastmcp_server.py
+++ b/src/spotify_mcp/fastmcp_server.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from typing import TYPE_CHECKING, cast
 
 from mcp.server.fastmcp import Context, FastMCP
@@ -28,6 +29,8 @@ from spotify_mcp.logging_utils import (
 from spotify_mcp.utils import to_id, to_uri
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from spotify_mcp.spotify_types import (
         AlbumObject,
         AlbumRef,
@@ -416,6 +419,70 @@ def get_me() -> UserProfile:
         raise convert_spotify_error(e) from e
 
 
+# Spotify's player writes are asynchronous: /me/player/play and friends answer 204
+# immediately, but a GET straight afterwards can still serve the pre-action state, or
+# None while an idle device wakes up (which reads back as is_playing=False with every
+# field empty). So confirm the action landed instead of trusting one immediate read.
+_CONFIRM_ATTEMPTS = 5
+_CONFIRM_DELAY_S = 0.2
+
+
+def _playback_confirmed(
+    action: str,
+    *,
+    previous_track_id: str | None = None,
+    position_ms: int | None = None,
+    volume_percent: int | None = None,
+    state: str | None = None,
+) -> Callable[[PlaybackState], bool]:
+    """Build the test for "this action has taken effect" for a given action.
+
+    Anything without a meaningful test accepts the first read, preserving the old
+    behaviour rather than spending attempts on a condition that can never be met.
+    """
+    if action == "play":
+        # Only playing/not-playing is reliable here: with shuffle on, a context does
+        # not necessarily start on its first track, so the track cannot be predicted.
+        return lambda s: s.is_playing
+    if action == "pause":
+        return lambda s: not s.is_playing
+    if action in ("next", "previous"):
+        # A fresh track id, or any track at all if nothing was playing before.
+        return lambda s: s.track is not None and s.track.id != previous_track_id
+    if action == "volume":
+        return lambda s: s.volume == volume_percent
+    if action == "shuffle":
+        return lambda s: s.shuffle is (state == "on")
+    if action == "repeat":
+        return lambda s: s.repeat == state
+    if action == "seek" and position_ms is not None:
+        # Playback keeps advancing, so accept a window ahead of the target rather
+        # than an exact match, and reject a stale position from before the seek.
+        return lambda s: (
+            s.progress_ms is not None
+            and position_ms - 500 <= s.progress_ms <= position_ms + 5000
+        )
+    return lambda _s: True
+
+
+def _await_playback(
+    matches: Callable[[PlaybackState], bool],
+) -> PlaybackState:
+    """Read playback state until `matches` holds, then return it.
+
+    Returns the last state read once the attempts are exhausted, so a device that
+    genuinely never reaches the expected state degrades to the old behaviour rather
+    than raising or blocking.
+    """
+    state = _playback_state()
+    for _ in range(_CONFIRM_ATTEMPTS - 1):
+        if matches(state):
+            return state
+        time.sleep(_CONFIRM_DELAY_S)
+        state = _playback_state()
+    return state
+
+
 def _playback_state() -> PlaybackState:
     """Read the current playback state into our model."""
     result = spotify_client.current_playback()
@@ -484,10 +551,21 @@ def control_playback(
         device_id: Target device (default: the currently active one)
 
     Returns:
-        PlaybackState after the action
+        PlaybackState after the action has been confirmed to have taken effect.
+
+    Note: Spotify applies player changes asynchronously, so the state is read back
+    until it reflects the action rather than once immediately.
     """
     try:
         logger.info(f"🎵 Playback action '{action}' (device={device_id or 'active'})")
+
+        # `next`/`previous` are confirmed by the track changing, so the outgoing
+        # track has to be known before the action is issued.
+        previous_track_id: str | None = None
+        if action in ("next", "previous"):
+            before = _playback_state()
+            previous_track_id = before.track.id if before.track else None
+
         if action == "play":
             if context_uri:
                 spotify_client.start_playback(
@@ -526,7 +604,15 @@ def control_playback(
         else:
             raise ValueError(f"Invalid action: {action}")
 
-        return _playback_state()
+        return _await_playback(
+            _playback_confirmed(
+                action,
+                previous_track_id=previous_track_id,
+                position_ms=position_ms,
+                volume_percent=volume_percent,
+                state=state,
+            )
+        )
 
     except SpotifyException as e:
         raise convert_spotify_error(e) from e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,16 @@ def reset_regime_cache():
     spotify_api._legacy_families.clear()
 
 
+@pytest.fixture(autouse=True)
+def no_playback_confirm_delay():
+    """`control_playback` waits between read-backs while confirming an action took
+    effect. A static mock never changes, so every unconfirmable action would burn the
+    full delay budget and the suite would crawl. Attempt count is left alone so the
+    retry behaviour itself stays under test."""
+    with patch("spotify_mcp.fastmcp_server._CONFIRM_DELAY_S", 0):
+        yield
+
+
 # Sample Spotify API response data for testing
 SAMPLE_TRACK = {
     "id": "4iV5W9uYEdYUVa79Axb7Rh",

--- a/tests/test_fastmcp_tools.py
+++ b/tests/test_fastmcp_tools.py
@@ -154,6 +154,116 @@ class TestControlPlayback:
             control_playback("teleport")
 
 
+class TestControlPlaybackReadBack:
+    """Spotify applies player changes asynchronously, so the state is read back until
+    it reflects the action. These drive the stale-then-fresh sequence a single
+    immediate read would have returned wrongly."""
+
+    TRACK = {
+        "name": "Never Gonna Give You Up",
+        "artists": [{"name": "Rick Astley", "id": "0gxyHStUsqpMadRV0Di1Qt"}],
+        "album": {"name": "Whenever You Need Somebody", "id": "6XzKGcM6laRkTrME3rQvJw"},
+        "duration_ms": 213573,
+    }
+
+    def _playing(self, track_id="4iV5W9uYEdYUVa79Axb7Rh", **over):
+        state = {
+            "is_playing": True,
+            "item": {**self.TRACK, "id": track_id},
+            "device": {"name": "My iPhone", "volume_percent": 70},
+            "shuffle_state": False,
+            "repeat_state": "off",
+            "progress_ms": 1000,
+        }
+        state.update(over)
+        return state
+
+    def test_play_waits_out_an_idle_device(self, mock_spotify_api):
+        """A waking device answers None, which reads back as an empty, not-playing
+        state. The old code returned that."""
+        mock_spotify_api.current_playback.side_effect = [
+            None,
+            None,
+            self._playing(),
+        ]
+
+        result = control_playback("play")
+
+        assert result.is_playing is True
+        assert result.track is not None
+        assert result.track.id == "4iV5W9uYEdYUVa79Axb7Rh"
+
+    def test_play_waits_past_the_pre_action_state(self, mock_spotify_api):
+        mock_spotify_api.current_playback.side_effect = [
+            self._playing(is_playing=False),
+            self._playing(),
+        ]
+
+        assert control_playback("play").is_playing is True
+
+    def test_pause_waits_for_playback_to_stop(self, mock_spotify_api):
+        mock_spotify_api.current_playback.side_effect = [
+            self._playing(),
+            self._playing(is_playing=False),
+        ]
+
+        assert control_playback("pause").is_playing is False
+
+    def test_next_waits_for_the_track_to_change(self, mock_spotify_api):
+        mock_spotify_api.current_playback.side_effect = [
+            self._playing(track_id="old"),  # pre-action read
+            self._playing(track_id="old"),  # still stale
+            self._playing(track_id="new"),
+        ]
+
+        result = control_playback("next")
+
+        assert result.track is not None
+        assert result.track.id == "new"
+
+    def test_shuffle_waits_for_the_flag(self, mock_spotify_api):
+        mock_spotify_api.current_playback.side_effect = [
+            self._playing(shuffle_state=False),
+            self._playing(shuffle_state=True),
+        ]
+
+        assert control_playback("shuffle", state="on").shuffle is True
+
+    def test_volume_waits_for_the_level(self, mock_spotify_api):
+        mock_spotify_api.current_playback.side_effect = [
+            self._playing(device={"name": "My iPhone", "volume_percent": 70}),
+            self._playing(device={"name": "My iPhone", "volume_percent": 30}),
+        ]
+
+        assert control_playback("volume", volume_percent=30).volume == 30
+
+    def test_seek_rejects_a_stale_position(self, mock_spotify_api):
+        mock_spotify_api.current_playback.side_effect = [
+            self._playing(progress_ms=1000),
+            self._playing(progress_ms=42120),
+        ]
+
+        assert control_playback("seek", position_ms=42000).progress_ms == 42120
+
+    def test_gives_up_rather_than_hanging(self, mock_spotify_api):
+        """A device that never reports the change must not block or raise — the last
+        state read is returned, matching the old behaviour."""
+        mock_spotify_api.current_playback.return_value = self._playing(is_playing=False)
+
+        result = control_playback("play")
+
+        assert result.is_playing is False
+        assert mock_spotify_api.current_playback.call_count == 5
+
+    def test_no_extra_reads_when_already_confirmed(self, mock_spotify_api):
+        """The happy path must stay a single read."""
+        mock_spotify_api.current_playback.return_value = self._playing()
+
+        control_playback("play")
+
+        assert mock_spotify_api.current_playback.call_count == 1
+
+
 class TestListDevices:
     def test_lists_devices(self, mock_spotify_api):
         mock_spotify_api.devices.return_value = {


### PR DESCRIPTION
## Problem

`control_playback` performs its action and then reads the state back exactly once. Spotify's player writes are asynchronous — `PUT /me/player/play` and friends answer `204` immediately — so that single read races the change and frequently returns the state from **before** the action.

Two shapes, both hit repeatedly against the live API:

**1. Idle device.** `current_playback()` returns `None` while the device wakes, which `_playback_state` maps to `is_playing=False` with every field empty. A successful `play` reads back as "nothing is playing":

```
control_playback(play, context_uri=...)
  -> {"is_playing": false, "track": null, "device": null, "volume": null, "progress_ms": null}
get_playback_state()          # moments later
  -> {"is_playing": true, "track": "Bigger", "device": "PM-...", "progress_ms": 3511}
```

**2. Pre-action state.** Enabling shuffle reports `shuffle: false`; starting a playlist reports the *previous* track with `is_playing: false`:

```
control_playback(shuffle, state=on)   -> shuffle: false      # actually on
control_playback(play, context_uri=…) -> previous track, is_playing: false
get_playback_state()                  -> Silence — Delerium, shuffle: true
```

A caller can't distinguish either from a genuine failure. The honest reading of a successful call becomes "ignore this return value and poll `get_playback_state`", which defeats the purpose of returning `PlaybackState` at all. It also makes the tool misleading to an LLM caller, which will happily report "playback didn't start" to the user.

## Fix

Confirm the action rather than trusting one read: poll until an action-specific condition holds, up to **5 attempts 200 ms apart**, and return the last state read if it never does.

- **Failure mode is unchanged** — a device that never reports the change returns the same state today's code would, rather than hanging or raising.
- **Happy path is still a single request** — an already-correct first read returns immediately, so no latency is added to the common case.

Conditions are deliberately conservative rather than clever:

| action | condition |
|---|---|
| `play` | `is_playing` only — with shuffle on, a context need not start on its first track, so the track can't be predicted |
| `pause` | `not is_playing` |
| `next` / `previous` | track id differs from the outgoing one (these read state once before acting to learn it) |
| `volume` / `shuffle` / `repeat` | matches what was requested |
| `seek` | a window ahead of the target, since playback keeps advancing — and rejects a position from before the seek |

## Testing

- `ruff check`, `ruff format --check`, `mypy src/`, `bandit -r src/` all clean
- `pytest`: **178 passed** (9 new), suite still runs in 0.16s
- A static mock never satisfies a condition, so an autouse fixture zeroes the delay in tests; the attempt count is left alone so the retry behaviour itself stays under test. Without that the suite went from 0.14s to 4.24s, which is worth knowing if you add player tests later.
- New tests drive the stale-then-fresh sequences directly, plus the two boundaries that matter: it **gives up rather than hanging** (returns the unconfirmed state after exactly 5 reads), and it makes **no extra reads when already confirmed**.

Live-verified against the real API, reproducing each case that failed before:

```
1. shuffle on          -> returned shuffle=True
2. play playlist ctx   -> returned is_playing=True track='Flaming June'
3. next                -> returned track='Love Stimulation - Love Club Mix'
4. volume 55           -> returned volume=55
5. pause               -> returned is_playing=False
independent check      -> is_playing=False shuffle=True volume=55
```

## Relationship to my other PRs

Independent of #19, #20, #21 and #22 — no shared lines, any merge order works. This one is a bit different in kind: those are withheld-endpoint defects, this is an eventual-consistency race in our own read-back.